### PR TITLE
small fix to hook build options in Makefile

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -21,7 +21,7 @@ OBJECTS = remopts_messages.o \
 		  version.o
 
 ../kea-hook-remote-opts.so: $(OBJECTS)
-	$(CXX) -o $@ $(CXXFLAGS) $(LDFLAGS) $(OBJECTS) -lcurl
+	$(CXX) -o $@ $(CXXFLAGS) $(OBJECTS) $(LDFLAGS)
 
 %.o: %.cc
 	$(CXX) -MMD -c $(CXXFLAGS) -o $@ $<


### PR DESCRIPTION
Fixed build options to correctly link dynamic libraries in hook so file